### PR TITLE
Added offer slugs used to generate seo friendly urls

### DIFF
--- a/php/hireinsocial/composer.json
+++ b/php/hireinsocial/composer.json
@@ -57,7 +57,9 @@
         "symfony/monolog-bundle": "^3.3",
         "doctrine/orm": "^2.6",
         "symfony/stopwatch": "^4.2",
-        "twig/extensions": "^1.5"
+        "twig/extensions": "^1.5",
+        "hashids/hashids": "^3.0",
+        "cocur/slugify": "^3.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.5",

--- a/php/hireinsocial/composer.lock
+++ b/php/hireinsocial/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d39217d6e94242695b53f4d112b6b74c",
+    "content-hash": "3f61ec745a9cee4529b5496b7f046ca4",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -60,6 +60,71 @@
                 "validation"
             ],
             "time": "2018-12-24T15:25:25+00:00"
+        },
+        {
+            "name": "cocur/slugify",
+            "version": "v3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cocur/slugify.git",
+                "reference": "d41701efe58ba2df9cae029c3d21e1518cc6780e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cocur/slugify/zipball/d41701efe58ba2df9cae029c3d21e1518cc6780e",
+                "reference": "d41701efe58ba2df9cae029c3d21e1518cc6780e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": ">=5.5.9"
+            },
+            "require-dev": {
+                "laravel/framework": "~5.1",
+                "latte/latte": "~2.2",
+                "league/container": "^2.2.0",
+                "mikey179/vfsstream": "~1.6",
+                "mockery/mockery": "~0.9",
+                "nette/di": "~2.2",
+                "phpunit/phpunit": "~4.8.36|~5.2",
+                "pimple/pimple": "~1.1",
+                "plumphp/plum": "~0.1",
+                "silex/silex": "~1.3",
+                "symfony/config": "~2.4|~3.0|~4.0",
+                "symfony/dependency-injection": "~2.4|~3.0|~4.0",
+                "symfony/http-kernel": "~2.4|~3.0|~4.0",
+                "twig/twig": "~1.26|~2.0",
+                "zendframework/zend-modulemanager": "~2.2",
+                "zendframework/zend-servicemanager": "~2.2",
+                "zendframework/zend-view": "~2.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Cocur\\Slugify\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ivo Bathke",
+                    "email": "ivo.bathke@gmail.com"
+                },
+                {
+                    "name": "Florian Eckerstorfer",
+                    "email": "florian@eckerstorfer.co",
+                    "homepage": "https://florian.ec"
+                }
+            ],
+            "description": "Converts a string into a slug.",
+            "keywords": [
+                "slug",
+                "slugify"
+            ],
+            "time": "2019-01-31T20:38:55+00:00"
         },
         {
             "name": "doctrine/annotations",
@@ -1053,6 +1118,72 @@
                 "sdk"
             ],
             "time": "2018-12-11T22:56:31+00:00"
+        },
+        {
+            "name": "hashids/hashids",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ivanakimov/hashids.php.git",
+                "reference": "b6c61142bfe36d43740a5419d11c351dddac0458"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ivanakimov/hashids.php/zipball/b6c61142bfe36d43740a5419d11c351dddac0458",
+                "reference": "b6c61142bfe36d43740a5419d11c351dddac0458",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.0"
+            },
+            "suggest": {
+                "ext-bcmath": "Required to use BC Math arbitrary precision mathematics (*).",
+                "ext-gmp": "Required to use GNU multiple precision mathematics (*)."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Hashids\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ivan Akimov",
+                    "email": "ivan@barreleye.com",
+                    "homepage": "https://twitter.com/IvanAkimov"
+                },
+                {
+                    "name": "Vincent Klaiber",
+                    "email": "hello@vinkla.com",
+                    "homepage": "https://vinkla.com"
+                }
+            ],
+            "description": "Generate short, unique, non-sequential ids (like YouTube and Bitly) from numbers",
+            "homepage": "http://hashids.org/php",
+            "keywords": [
+                "bitly",
+                "decode",
+                "encode",
+                "hash",
+                "hashid",
+                "hashids",
+                "ids",
+                "obfuscate",
+                "youtube"
+            ],
+            "time": "2018-03-12T16:30:09+00:00"
         },
         {
             "name": "monolog/monolog",

--- a/php/hireinsocial/db/migrations/2019/02/Version20190209182306.php
+++ b/php/hireinsocial/db/migrations/2019/02/Version20190209182306.php
@@ -8,7 +8,7 @@ use Doctrine\Migrations\AbstractMigration;
 /**
  * Auto-generated Migration: Please modify to your needs!
  */
-final class Version20190205104726 extends AbstractMigration
+final class Version20190209182306 extends AbstractMigration
 {
     public function up(Schema $schema) : void
     {
@@ -17,6 +17,8 @@ final class Version20190205104726 extends AbstractMigration
 
         $this->addSql('CREATE TABLE his_specialization (id UUID NOT NULL, slug VARCHAR(255) NOT NULL, facebook_channel_page_fb_id VARCHAR(255) NOT NULL, facebook_channel_page_access_token VARCHAR(255) NOT NULL, facebook_channel_group_fb_id VARCHAR(255) NOT NULL, PRIMARY KEY(id))');
         $this->addSql('CREATE UNIQUE INDEX UNIQ_E60FD12B989D9B62 ON his_specialization (slug)');
+        $this->addSql('CREATE TABLE his_job_offer_slug (slug TEXT NOT NULL, offer_id UUID NOT NULL, created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, PRIMARY KEY(slug))');
+        $this->addSql('COMMENT ON COLUMN his_job_offer_slug.created_at IS \'(DC2Type:datetime_immutable)\'');
         $this->addSql('CREATE TABLE his_facebook_post (fb_id VARCHAR(255) NOT NULL, job_offer_id UUID NOT NULL, fb_author_id VARCHAR(255) NOT NULL, PRIMARY KEY(fb_id))');
         $this->addSql('CREATE TABLE his_job_offer (id UUID NOT NULL, specialization_id UUID NOT NULL, created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, salary JSON DEFAULT NULL, company_name VARCHAR(255) NOT NULL, company_url VARCHAR(2083) NOT NULL, company_description VARCHAR(512) NOT NULL, position_name VARCHAR(255) NOT NULL, position_description VARCHAR(1024) NOT NULL, location_remote BOOLEAN NOT NULL, location_name VARCHAR(512) DEFAULT NULL, contract_type VARCHAR(255) NOT NULL, description_requirements VARCHAR(1024) NOT NULL, description_benefits VARCHAR(1024) NOT NULL, contact_email VARCHAR(255) NOT NULL, contact_name VARCHAR(255) NOT NULL, contact_phone VARCHAR(16) NOT NULL, PRIMARY KEY(id))');
         $this->addSql('COMMENT ON COLUMN his_job_offer.created_at IS \'(DC2Type:datetime_immutable)\'');
@@ -29,6 +31,7 @@ final class Version20190205104726 extends AbstractMigration
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
 
         $this->addSql('DROP TABLE his_specialization');
+        $this->addSql('DROP TABLE his_job_offer_slug');
         $this->addSql('DROP TABLE his_facebook_post');
         $this->addSql('DROP TABLE his_job_offer');
     }

--- a/php/hireinsocial/db/orm/mapping/xml/Offer.Slug.orm.xml
+++ b/php/hireinsocial/db/orm/mapping/xml/Offer.Slug.orm.xml
@@ -1,0 +1,13 @@
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                          https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+    <entity name="HireInSocial\Application\Offer\Slug" table="his_job_offer_slug">
+
+        <id name="slug" type="text">
+            <generator strategy="NONE" />
+        </id>
+        <field name="offerId" type="guid" />
+        <field name="createdAt" type="datetime_immutable" />
+    </entity>
+</doctrine-mapping>

--- a/php/hireinsocial/resources/templates/pl_PL/ui/base.html.twig
+++ b/php/hireinsocial/resources/templates/pl_PL/ui/base.html.twig
@@ -16,6 +16,7 @@
 {{ render(controller('HireInSocial\\UserInterface\\Symfony\\Controller\\LayoutController::navbarAction')) }}
 
 <div class="container">
+    {% block hero_block %}
     <div class="py-5 text-center">
         <h2><a href="{{ url('home') }}">Hire in Social!</a></h2>
         <p class="lead">
@@ -25,6 +26,7 @@
             Ten prosty system ma na celu automatyzację procesu dodawania ofert pracy na portalu społecznościowym Facebook.
         </p>
     </div>
+    {% endblock %}
     {% block body %}{% endblock %}
     <footer class="pt-4 my-md-5 pt-md-5 border-top">
         <div class="row">

--- a/php/hireinsocial/resources/templates/pl_PL/ui/offer/offer.html.twig
+++ b/php/hireinsocial/resources/templates/pl_PL/ui/offer/offer.html.twig
@@ -1,0 +1,82 @@
+{% extends 'base.html.twig' %}
+
+{% block hero_block %}{% endblock %}
+
+{% block body %}
+    <h1>{{ offer.position.name }} <span class="text-muted">w</span> {{ offer.company.name }}</strong></h1>
+    <div class="row">
+        <div class="col-6">
+            <h4>Opis Stanowiska</h4>
+            <div class="card">
+                <div class="card-body">
+                    <p>
+                        {{ offer.position.description }}
+                    </p>
+                </div>
+            </div>
+        </div>
+        <div class="col-6">
+            <h4>Wynagrodzenie</h4>
+
+            {% if offer.salary %}
+            <div class="card">
+                <div class="card-body">
+                    {{ offer.salary.min|localizedcurrency(offer.salary.currencyCode) }} - {{ offer.salary.max|localizedcurrency(offer.salary.currencyCode) }}
+                    {% if offer.salary.isNet %}<strong class="text-success">netto</strong>{% else %}<strong class="text-warning">brutto</strong>{% endif %}
+                </div>
+            </div>
+            {% else %}
+                <div class="alert alert-warning">
+                    W tym ogłoszeniu pracodawca nie zdefiniował widełek. Nie ma w tym nic złego, pamiętaj że możesz rozpocząć
+                    rozmowę od ustalenia zakresu wynagrodzenia jakim jesteś zainteresowany.
+                </div>
+            {% endif %}
+
+            <h4 class="mt-2">Kontakt</h4>
+            <div class="card">
+                <div class="card-body">
+                    <p>
+                        Jeżeli jesteś zainteresowany ofertą wyślij CV na adres: <a href="mailto:{{ offer.contact.email }}">{{ offer.contact.email }}</a>
+                    </p>
+                    <p class="text-right">
+                        {{ offer.contact.name }}
+                    </p>
+                </div>
+            </div>
+        </div>
+    </div>
+    <h2 class="mt-3">{{ offer.company.name }}</h2>
+    <div class="card">
+        <div class="card-body">
+            <p>
+                {{ offer.company.description }}
+            </p>
+
+            <p class="text-right">
+                <a href="{{ offer.company.url }}" class="btn-link">{{ offer.company.url }}</a>
+            </p>
+        </div>
+    </div>
+    <div class="row mt-3">
+        <div class="col-6">
+            <h3>Benefity</h3>
+            <div class="card">
+                <div class="card-body">
+                    <p>
+                        {{ offer.description.benefits }}
+                    </p>
+                </div>
+            </div>
+        </div>
+        <div class="col-6">
+            <h3>Wymagania</h3>
+            <div class="card">
+                <div class="card-body">
+                    <p>
+                        {{ offer.description.requirements }}
+                    </p>
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/php/hireinsocial/resources/templates/pl_PL/ui/specialization/offers.html.twig
+++ b/php/hireinsocial/resources/templates/pl_PL/ui/specialization/offers.html.twig
@@ -31,6 +31,9 @@
                     <p>
                         {{ offer.position.description|truncate(300) }}
                     </p>
+                    <p class="text-right">
+                        <a href="{{ url('offer', {slug : offer.slug}) }}" class="btn btn-primary btn-sm">Więcej</a>
+                    </p>
                 </div>
             </div>
         </div>

--- a/php/hireinsocial/src/HireInSocial/Application/Command/Facebook/Page/PostToGroupHandler.php
+++ b/php/hireinsocial/src/HireInSocial/Application/Command/Facebook/Page/PostToGroupHandler.php
@@ -18,6 +18,8 @@ use HireInSocial\Application\Offer\OfferFormatter;
 use HireInSocial\Application\Offer\Offers;
 use HireInSocial\Application\Offer\Position;
 use HireInSocial\Application\Offer\Salary;
+use HireInSocial\Application\Offer\Slug;
+use HireInSocial\Application\Offer\Slugs;
 use HireInSocial\Application\Specialization\Specialization;
 use HireInSocial\Application\Specialization\Specializations;
 use HireInSocial\Application\System\Calendar;
@@ -31,6 +33,7 @@ final class PostToGroupHandler implements Handler
     private $formatter;
     private $posts;
     private $specializations;
+    private $slugs;
 
     public function __construct(
         Calendar $calendar,
@@ -38,7 +41,8 @@ final class PostToGroupHandler implements Handler
         Posts $posts,
         FacebookGroupService $facebookGroupService,
         OfferFormatter $formatter,
-        Specializations $specializations
+        Specializations $specializations,
+        Slugs $slugs
     ) {
         $this->calendar = $calendar;
         $this->facebookGroupService = $facebookGroupService;
@@ -46,6 +50,7 @@ final class PostToGroupHandler implements Handler
         $this->offers = $offers;
         $this->posts = $posts;
         $this->specializations = $specializations;
+        $this->slugs = $slugs;
     }
 
     public function handles(): string
@@ -73,6 +78,7 @@ final class PostToGroupHandler implements Handler
         );
         $this->posts->add(new Post($postId, $offer, $draft));
         $this->offers->add($offer);
+        $this->slugs->add(Slug::from($offer, $this->calendar));
     }
 
     private function createOffer(PostToGroup $command, Specialization $specialization): Offer

--- a/php/hireinsocial/src/HireInSocial/Application/Offer/Slug.php
+++ b/php/hireinsocial/src/HireInSocial/Application/Offer/Slug.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HireInSocial\Application\Offer;
+
+use Cocur\Slugify\Slugify;
+use Hashids\Hashids;
+use HireInSocial\Application\System\Calendar;
+use Ramsey\Uuid\UuidInterface;
+
+class Slug
+{
+    private $slug;
+    private $offerId;
+    private $createdAt;
+
+    private function __construct(string $value, UuidInterface $offerId, \DateTimeImmutable $createdAt)
+    {
+        $this->slug = $value;
+        $this->offerId = $offerId;
+        $this->createdAt = $createdAt;
+    }
+
+    public static function from(Offer $offer, Calendar $calendar) : self
+    {
+        $hashids = new Hashids();
+        $slugify = new Slugify();
+
+        return new self(
+            sprintf('%s-%s', $slugify->slugify($offer->position()->name() . ' ' . $offer->company()->name()), $hashids->encode(time())),
+            $offer->id(),
+            $calendar->currentTime()
+        );
+    }
+
+    public function __toString() : string
+    {
+        return $this->slug;
+    }
+}

--- a/php/hireinsocial/src/HireInSocial/Application/Offer/Slugs.php
+++ b/php/hireinsocial/src/HireInSocial/Application/Offer/Slugs.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HireInSocial\Application\Offer;
+
+interface Slugs
+{
+    public function add(Slug $slug) : void;
+}

--- a/php/hireinsocial/src/HireInSocial/Application/Query/Offer/Model/Offer.php
+++ b/php/hireinsocial/src/HireInSocial/Application/Query/Offer/Model/Offer.php
@@ -17,6 +17,7 @@ use Ramsey\Uuid\UuidInterface;
 final class Offer
 {
     private $id;
+    private $slug;
     private $createdAt;
     private $company;
     private $contact;
@@ -27,6 +28,7 @@ final class Offer
     private $salary;
 
     public function __construct(
+        string $slug,
         UuidInterface $id,
         \DateTimeImmutable $createdAt,
         Company $company,
@@ -37,6 +39,7 @@ final class Offer
         Position $position,
         ?Salary $salary
     ) {
+        $this->slug = $slug;
         $this->id = $id;
         $this->createdAt = $createdAt;
         $this->company = $company;
@@ -46,6 +49,11 @@ final class Offer
         $this->location = $location;
         $this->position = $position;
         $this->salary = $salary;
+    }
+
+    public function slug(): string
+    {
+        return $this->slug;
     }
 
     public function id(): UuidInterface

--- a/php/hireinsocial/src/HireInSocial/Application/Query/Offer/Model/Offers.php
+++ b/php/hireinsocial/src/HireInSocial/Application/Query/Offer/Model/Offers.php
@@ -10,4 +10,9 @@ final class Offers extends \ArrayObject
     {
         parent::__construct($offers);
     }
+
+    public function first() : Offer
+    {
+        return \current((array) $this);
+    }
 }

--- a/php/hireinsocial/src/HireInSocial/Application/Query/Offer/OfferQuery.php
+++ b/php/hireinsocial/src/HireInSocial/Application/Query/Offer/OfferQuery.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace HireInSocial\Application\Query\Offer;
 
+use HireInSocial\Application\Query\Offer\Model\Offer;
 use HireInSocial\Application\Query\Offer\Model\Offers;
 use HireInSocial\Application\System\Query;
 
@@ -11,5 +12,6 @@ interface OfferQuery extends Query
 {
     public function total() : int;
     public function count(OfferFilter $filter) : int;
-    public function find(OfferFilter $filter) : Offers;
+    public function findAll(OfferFilter $filter) : Offers;
+    public function findBySlug(string $slug) : ?Offer;
 }

--- a/php/hireinsocial/src/HireInSocial/Infrastructure/Doctrine/ORM/Application/Offer/ORMSlugs.php
+++ b/php/hireinsocial/src/HireInSocial/Infrastructure/Doctrine/ORM/Application/Offer/ORMSlugs.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HireInSocial\Infrastructure\Doctrine\ORM\Application\Offer;
+
+use Doctrine\ORM\EntityManager;
+use HireInSocial\Application\Offer\Slug;
+use HireInSocial\Application\Offer\Slugs;
+
+final class ORMSlugs implements Slugs
+{
+    private $entityManager;
+
+    public function __construct(EntityManager $entityManager)
+    {
+        $this->entityManager = $entityManager;
+    }
+
+    public function add(Slug $slug): void
+    {
+        $this->entityManager->persist($slug);
+    }
+}

--- a/php/hireinsocial/src/HireInSocial/UserInterface/Symfony/Controller/OfferController.php
+++ b/php/hireinsocial/src/HireInSocial/UserInterface/Symfony/Controller/OfferController.php
@@ -14,6 +14,7 @@ use HireInSocial\Application\Command\Offer\Offer;
 use HireInSocial\Application\Command\Offer\Position;
 use HireInSocial\Application\Command\Offer\Salary;
 use HireInSocial\Application\Exception\Exception;
+use HireInSocial\Application\Query\Offer\OfferQuery;
 use HireInSocial\Application\Query\Offer\OfferThrottleQuery;
 use HireInSocial\Application\Query\Specialization\SpecializationQuery;
 use HireInSocial\Application\System;
@@ -82,6 +83,19 @@ final class OfferController extends AbstractController
 
         return $this->render('/offer/success.html.twig', [
             'specialization' => $specialization,
+        ]);
+    }
+
+    public function offerAction(string $slug) : Response
+    {
+        $offer = $this->get(System::class)->query(OfferQuery::class)->findBySlug($slug);
+
+        if (!$offer) {
+            throw $this->createNotFoundException();
+        }
+
+        return $this->render('offer/offer.html.twig', [
+            'offer' => $offer,
         ]);
     }
 }

--- a/php/hireinsocial/src/HireInSocial/UserInterface/Symfony/Controller/SpecializationController.php
+++ b/php/hireinsocial/src/HireInSocial/UserInterface/Symfony/Controller/SpecializationController.php
@@ -26,7 +26,7 @@ final class SpecializationController extends AbstractController
 
         $offers = $this->get(System::class)
             ->query(OfferQuery::class)
-            ->find($offerFilter);
+            ->findAll($offerFilter);
 
         return $this->render('/specialization/offers.html.twig', [
             'total' => $this->get(System::class)->query(OfferQuery::class)->count($offerFilter),

--- a/php/hireinsocial/src/HireInSocial/UserInterface/Symfony/SymfonyKernel.php
+++ b/php/hireinsocial/src/HireInSocial/UserInterface/Symfony/SymfonyKernel.php
@@ -105,6 +105,7 @@ final class SymfonyKernel extends Kernel
         $routes->add('/facebook/login', [FacebookController::class, 'loginAction'], 'facebook_login');
         $routes->add('/facebook/logout', [FacebookController::class, 'logoutAction'], 'facebook_logout');
         $routes->add('/facebook/login/success', [FacebookController::class, 'loginSuccessAction'], 'facebook_login_success');
+        $routes->add('/offer/{slug}', [OfferController::class, 'offerAction'], 'offer');
         $routes->add('/{specialization}/offer', [OfferController::class, 'newAction'], 'offer_new');
         $routes->add('/{specialization}/offer/success', [OfferController::class, 'successAction'], 'offer_success');
         $routes->add('/{slug}', [SpecializationController::class, 'offersAction'], 'specialization_offers');

--- a/php/hireinsocial/src/HireInSocial/system.php
+++ b/php/hireinsocial/src/HireInSocial/system.php
@@ -14,6 +14,7 @@ use HireInSocial\Infrastructure\Doctrine\DBAL\Application\Offer\DbalOfferQuery;
 use HireInSocial\Infrastructure\Doctrine\DBAL\Application\Specialization\DBALSpecializationQuery;
 use HireInSocial\Infrastructure\Doctrine\ORM\Application\Facebook\ORMPosts;
 use HireInSocial\Infrastructure\Doctrine\ORM\Application\Offer\ORMOffers;
+use HireInSocial\Infrastructure\Doctrine\ORM\Application\Offer\ORMSlugs;
 use HireInSocial\Infrastructure\Doctrine\ORM\Application\Specialization\ORMSpecializations;
 use HireInSocial\Infrastructure\Doctrine\ORM\Application\System\ORMTransactionManager;
 use HireInSocial\Infrastructure\Facbook\FacebookGraphSDK;
@@ -98,7 +99,8 @@ function system(Config $config) : System
                     $offerThrottle
                 ),
                 new FacebookFormatter($twig),
-                new ORMSpecializations($entityManager)
+                new ORMSpecializations($entityManager),
+                new ORMSlugs($entityManager)
             ),
             new RemoveThrottleHandler(
                 $offerThrottle

--- a/php/hireinsocial/tests/HireInSocial/Tests/Application/Functional/Symfony/OfferTest.php
+++ b/php/hireinsocial/tests/HireInSocial/Tests/Application/Functional/Symfony/OfferTest.php
@@ -4,17 +4,32 @@ declare(strict_types=1);
 
 namespace HireInSocial\Tests\Application\Functional\Symfony;
 
+use HireInSocial\Application\Query\Offer\OfferFilter;
+use HireInSocial\Application\Query\Offer\OfferQuery;
 use HireInSocial\Tests\Application\Functional\WebTestCase;
 
 final class OfferTest extends WebTestCase
 {
     public function test_offer_success_page()
     {
-        $slug = 'slug';
+        $specialization = 'spec';
         $client = static::createClient();
-        $this->systemContext->createSpecialization($slug);
+        $this->systemContext->createSpecialization($specialization);
 
-        $client->request('GET', $client->getContainer()->get('router')->generate('offer_success', ['specialization' => $slug]));
+        $client->request('GET', $client->getContainer()->get('router')->generate('offer_success', ['specialization' => $specialization]));
+        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+    }
+
+    public function test_offer_accessing_offer_page()
+    {
+        $specialization = 'spec';
+        $client = static::createClient();
+        $this->systemContext->createSpecialization($specialization);
+        $this->systemContext->postToFacebookGroup('FB_USER_ID', $specialization);
+
+        $offer = $this->system()->query(OfferQuery::class)->findAll(OfferFilter::allFor($specialization))->first();
+
+        $client->request('GET', $client->getContainer()->get('router')->generate('offer', ['slug' => $offer->slug()]));
         $this->assertEquals(200, $client->getResponse()->getStatusCode());
     }
 }

--- a/php/hireinsocial/tests/HireInSocial/Tests/Application/MotherObject/Offer/OfferMother.php
+++ b/php/hireinsocial/tests/HireInSocial/Tests/Application/MotherObject/Offer/OfferMother.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HireInSocial\Tests\Application\MotherObject\Offer;
+
+use Faker\Factory;
+use HireInSocial\Application\Offer;
+use HireInSocial\Tests\Application\MotherObject\Facebook\CalendarMother;
+use Ramsey\Uuid\Uuid;
+
+final class OfferMother
+{
+    public static function withName(string $positionName, string $companyName)
+    {
+        $faker = Factory::create();
+
+        return new Offer\Offer(
+            Uuid::uuid4(),
+            new Offer\Company($companyName, $faker->url, $faker->text(512)),
+            new Offer\Position($positionName, $faker->text(1024)),
+            new Offer\Location($faker->boolean, $faker->country),
+            new Offer\Salary($faker->numberBetween(1000, 5000), $faker->numberBetween(5000, 20000), 'PLN', $faker->boolean),
+            new Offer\Contract('B2B'),
+            new Offer\Description(
+                $faker->text(1024),
+                $faker->text(1024)
+            ),
+            new Offer\Contact(
+                $faker->email,
+                $faker->name,
+                '+1 333333333'
+            ),
+            CalendarMother::utc()
+        );
+    }
+}

--- a/php/hireinsocial/tests/HireInSocial/Tests/Application/Unit/Offer/SlugTest.php
+++ b/php/hireinsocial/tests/HireInSocial/Tests/Application/Unit/Offer/SlugTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HireInSocial\Tests\Application\Unit\Offer;
+
+use HireInSocial\Application\Offer\Slug;
+use HireInSocial\Tests\Application\MotherObject\Facebook\CalendarMother;
+use HireInSocial\Tests\Application\MotherObject\Offer\OfferMother;
+use PHPStan\Testing\TestCase;
+
+final class SlugTest extends TestCase
+{
+    public function test_creating_offer_slug()
+    {
+        $order = OfferMother::withName('Senior PHP Developer', 'Super Company');
+
+        $this->assertRegExp(
+            '/^senior-php-developer-super-company-(.)+/',
+            (string) Slug::from($order, CalendarMother::utc())
+        );
+    }
+}


### PR DESCRIPTION
So I introduced `Offer\Slug` entity that is created always with Offer. Why this way instead of adding `$slug` property into the `Offer` directly? I think that in the future I might want to add also `Update Offer Feature` and keeping old slug when offer name or company name was changed makes no sense. 

Offer slug is generated by [Slugify](https://github.com/cocur/slugify) and [Hashids](https://github.com/ivanakimov/hashids.php) (id is added at the end of the slug and it's created from time). 

Slug structure format: 
```
{position-name}-{company-name}-{hashid}
```

Id used in slug is created from `time()` function, it's not perfect and it allows collisions but only when company name and offer nam are going to be exactly the same. I believe it's small risk, worst case scenario, I will generate id from some random number. 

![image](https://user-images.githubusercontent.com/1921950/52525881-d0c5c900-2cb0-11e9-9b94-4976e9bfd8bc.png)

![image](https://user-images.githubusercontent.com/1921950/52525882-d7544080-2cb0-11e9-8088-751a9deb4d5a.png)
