### PR TITLE
Store Facebook access token and use it to obtain Facebook application user id

### DIFF
--- a/php/hireinsocial/src/HireInSocial/UserInterface/Symfony/Controller/FacebookAccess.php
+++ b/php/hireinsocial/src/HireInSocial/UserInterface/Symfony/Controller/FacebookAccess.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HireInSocial\UserInterface\Symfony\Controller;
+
+use Facebook\Authentication\AccessToken;
+use Facebook\Facebook;
+use Psr\Log\LoggerInterface;
+
+trait FacebookAccess
+{
+    public function getUserId(Facebook $facebook, AccessToken $accessToken, LoggerInterface $logger) : string
+    {
+        $facebookResponse = $facebook->get('me', $accessToken);
+
+        $logger->debug('Facebook /me response', ['body' => $facebookResponse->getBody()]);
+
+        return $facebookResponse->getDecodedBody()['id'];
+    }
+}

--- a/php/hireinsocial/src/HireInSocial/UserInterface/Symfony/Controller/LayoutController.php
+++ b/php/hireinsocial/src/HireInSocial/UserInterface/Symfony/Controller/LayoutController.php
@@ -13,7 +13,7 @@ final class LayoutController extends AbstractController
     public function navbarAction(Request $request) : Response
     {
         return $this->render('layout/navbar.html.twig', [
-            'facebook_logged_in' => (bool) $request->getSession()->get(FacebookController::FACEBOOK_ID_SESSION_KEY, false),
+            'facebook_logged_in' => (bool) $request->getSession()->get(FacebookController::FACEBOOK_USER_TOKEN_SESSION_KEY, false),
         ]);
     }
 }

--- a/php/hireinsocial/src/HireInSocial/UserInterface/Symfony/Controller/OfferController.php
+++ b/php/hireinsocial/src/HireInSocial/UserInterface/Symfony/Controller/OfferController.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace HireInSocial\UserInterface\Symfony\Controller;
 
+use Facebook\Authentication\AccessToken;
+use Facebook\Facebook;
 use HireInSocial\Application\Command\Facebook\Page\PostToGroup;
 use HireInSocial\Application\Command\Offer\Company;
 use HireInSocial\Application\Command\Offer\Contact;
@@ -19,23 +21,44 @@ use HireInSocial\Application\Query\Offer\OfferThrottleQuery;
 use HireInSocial\Application\Query\Specialization\SpecializationQuery;
 use HireInSocial\Application\System;
 use HireInSocial\UserInterface\Symfony\Form\Type\OfferType;
+use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 final class OfferController extends AbstractController
 {
+    use FacebookAccess;
+
+    private $facebook;
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    public function __construct(Facebook $facebook, LoggerInterface $logger)
+    {
+        $this->facebook = $facebook;
+        $this->logger = $logger;
+    }
+
     public function newAction(string $specialization, Request $request) : Response
     {
-        if (!$request->getSession()->has(FacebookController::FACEBOOK_ID_SESSION_KEY)) {
+        try {
+            $fbUserId = $this->getUserId(
+                $this->facebook,
+                new AccessToken((string)$request->getSession()->get(FacebookController::FACEBOOK_USER_TOKEN_SESSION_KEY)),
+                $this->logger
+            );
+        } catch (\Throwable $exception) {
+            $this->logger->debug('Not authenticated, redirecting to facebook login.', ['exception' => $exception->getMessage()]);
+
             return $this->redirectToRoute('facebook_login');
         }
 
         if (!$this->get(System::class)->query(SpecializationQuery::class)->findBySlug($specialization)) {
             throw $this->createNotFoundException();
         }
-
-        $fbUserId = $request->getSession()->get(FacebookController::FACEBOOK_ID_SESSION_KEY);
 
         $form = $this->createForm(OfferType::class);
 


### PR DESCRIPTION
Store facebook auth token in session and use it to obtain facebook application user ID just before posting new offer instead of getting facebook app user id from session. 

Closes #10 