### PR TITLE
Load only routes for locale

### DIFF
--- a/php/hireinsocial/resources/templates/pl_PL/ui/home/index/specialization.html.twig
+++ b/php/hireinsocial/resources/templates/pl_PL/ui/home/index/specialization.html.twig
@@ -11,12 +11,12 @@
         </ul>
         <div class="card-body text-center">
             <p class="card-text">
-                <a href="{{ url('specialization_offers', {'slug' : specialization.slug}) }}" class="btn btn-primary btn-sm">Najnowsze Oferty</a>
+                <a href="{{ url('specialization_offers', {'specSlug' : specialization.slug}) }}" class="btn btn-primary btn-sm">Najnowsze Oferty</a>
                 <a href="{{ specialization.facebookChannel.groupId|fb_group_url }}" class="btn btn-secondary btn-sm" target="_blank"><i class="fab fa-facebook-f"></i> zobacz na Facebooku</a>
             </p>
         </div>
         <div class="card-footer">
-            <a href="{{ url('offer_new', {'specialization' : specialization.slug}) }}" class="btn btn-lg btn-block btn-primary">Napisz ogłoszenie</a>
+            <a href="{{ url('offer_new', {'specSlug' : specialization.slug}) }}" class="btn btn-lg btn-block btn-primary">Napisz ogłoszenie</a>
         </div>
     </div>
 </div>

--- a/php/hireinsocial/resources/templates/pl_PL/ui/specialization/offers.html.twig
+++ b/php/hireinsocial/resources/templates/pl_PL/ui/specialization/offers.html.twig
@@ -32,7 +32,7 @@
                         {{ offer.position.description|truncate(300) }}
                     </p>
                     <p class="text-right">
-                        <a href="{{ url('offer', {slug : offer.slug}) }}" class="btn btn-primary btn-sm">Więcej</a>
+                        <a href="{{ url('offer', {'offerSlug': offer.slug}) }}" class="btn btn-primary btn-sm">Więcej</a>
                     </p>
                 </div>
             </div>

--- a/php/hireinsocial/src/HireInSocial/UserInterface/Symfony/Controller/OfferController.php
+++ b/php/hireinsocial/src/HireInSocial/UserInterface/Symfony/Controller/OfferController.php
@@ -43,7 +43,7 @@ final class OfferController extends AbstractController
         $this->logger = $logger;
     }
 
-    public function newAction(string $specialization, Request $request) : Response
+    public function newAction(string $specSlug, Request $request) : Response
     {
         try {
             $fbUserId = $this->getUserId(
@@ -57,7 +57,7 @@ final class OfferController extends AbstractController
             return $this->redirectToRoute('facebook_login');
         }
 
-        if (!$this->get(System::class)->query(SpecializationQuery::class)->findBySlug($specialization)) {
+        if (!$this->get(System::class)->query(SpecializationQuery::class)->findBySlug($specSlug)) {
             throw $this->createNotFoundException();
         }
 
@@ -70,7 +70,7 @@ final class OfferController extends AbstractController
 
             try {
                 $this->container->get(System::class)->handle(new PostOffer(
-                    $specialization,
+                    $specSlug,
                     $fbUserId,
                     new Offer(
                         new Company($offer['company']['name'], $offer['company']['url'], $offer['company']['description']),
@@ -86,7 +86,7 @@ final class OfferController extends AbstractController
                     )
                 ));
 
-                return $this->redirectToRoute('offer_success', ['specialization' => $specialization]);
+                return $this->redirectToRoute('offer_success', ['specialization' => $specSlug]);
             } catch (Exception $exception) {
                 // TODO: Show some user friendly error message in UI.
                 throw $exception;
@@ -99,22 +99,22 @@ final class OfferController extends AbstractController
         ]);
     }
 
-    public function successAction(string $specialization) : Response
+    public function successAction(string $specSlug) : Response
     {
-        $specialization = $this->get(System::class)->query(SpecializationQuery::class)->findBySlug($specialization);
+        $specSlug = $this->get(System::class)->query(SpecializationQuery::class)->findBySlug($specSlug);
 
-        if (!$specialization) {
+        if (!$specSlug) {
             throw $this->createNotFoundException();
         }
 
         return $this->render('/offer/success.html.twig', [
-            'specialization' => $specialization,
+            'specialization' => $specSlug,
         ]);
     }
 
-    public function offerAction(string $slug) : Response
+    public function offerAction(string $offerSlug) : Response
     {
-        $offer = $this->get(System::class)->query(OfferQuery::class)->findBySlug($slug);
+        $offer = $this->get(System::class)->query(OfferQuery::class)->findBySlug($offerSlug);
 
         if (!$offer) {
             throw $this->createNotFoundException();

--- a/php/hireinsocial/src/HireInSocial/UserInterface/Symfony/Controller/SpecializationController.php
+++ b/php/hireinsocial/src/HireInSocial/UserInterface/Symfony/Controller/SpecializationController.php
@@ -13,9 +13,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 final class SpecializationController extends AbstractController
 {
-    public function offersAction(string $slug) : Response
+    public function offersAction(string $specSlug) : Response
     {
-        $specialization = $this->get(System::class)->query(SpecializationQuery::class)->findBySlug($slug);
+        $specialization = $this->get(System::class)->query(SpecializationQuery::class)->findBySlug($specSlug);
 
         if (!$specialization) {
             throw $this->createNotFoundException();

--- a/php/hireinsocial/src/HireInSocial/UserInterface/Symfony/SymfonyKernel.php
+++ b/php/hireinsocial/src/HireInSocial/UserInterface/Symfony/SymfonyKernel.php
@@ -105,9 +105,24 @@ final class SymfonyKernel extends Kernel
         $routes->add('/facebook/login', [FacebookController::class, 'loginAction'], 'facebook_login');
         $routes->add('/facebook/logout', [FacebookController::class, 'logoutAction'], 'facebook_logout');
         $routes->add('/facebook/login/success', [FacebookController::class, 'loginSuccessAction'], 'facebook_login_success');
-        $routes->add('/offer/{slug}', [OfferController::class, 'offerAction'], 'offer');
-        $routes->add('/{specialization}/offer', [OfferController::class, 'newAction'], 'offer_new');
-        $routes->add('/{specialization}/offer/success', [OfferController::class, 'successAction'], 'offer_success');
-        $routes->add('/{slug}', [SpecializationController::class, 'offersAction'], 'specialization_offers');
+
+        switch ($this->frameworkConfig['framework']['default_locale']) {
+            case 'pl_PL':
+                $routes->add('/oferty/{specSlug}/dodaj', [OfferController::class, 'newAction'], 'offer_new');
+                $routes->add('/oferty/{specSlug}/dodaj/sukces', [OfferController::class, 'successAction'], 'offer_success');
+                $routes->add('/oferty/{specSlug}', [SpecializationController::class, 'offersAction'], 'specialization_offers');
+                $routes->add('/oferta-pracy/{offerSlug}', [OfferController::class, 'offerAction'], 'offer');
+
+                break;
+            case 'en_US':
+                $routes->add('/offers//{specSlug}/new', [OfferController::class, 'newAction'], 'offer_new');
+                $routes->add('/offers//{specSlug}/new/success', [OfferController::class, 'successAction'], 'offer_success');
+                $routes->add('/offers/{specSlug}', [SpecializationController::class, 'offersAction'], 'specialization_offers');
+                $routes->add('/job-offer/{slug}', [OfferController::class, 'offerAction'], 'offer');
+
+                break;
+            default:
+                throw new \RuntimeException(sprintf('Unrecognized locale %s', $this->frameworkConfig['framework']['default_locale']));
+        }
     }
 }

--- a/php/hireinsocial/tests/HireInSocial/Tests/Application/Functional/Symfony/FacebookAuthenticationTest.php
+++ b/php/hireinsocial/tests/HireInSocial/Tests/Application/Functional/Symfony/FacebookAuthenticationTest.php
@@ -11,7 +11,7 @@ final class FacebookAuthenticationTest extends WebTestCase
     public function test_redirect_to_facebook_when_want_to_add_new_offer_not_logged()
     {
         $client = static::createClient();
-        $client->request('GET', $client->getContainer()->get('router')->generate('offer_new', ['specialization' => 'php']));
+        $client->request('GET', $client->getContainer()->get('router')->generate('offer_new', ['specSlug' => 'php']));
 
         $this->assertEquals(302, $client->getResponse()->getStatusCode());
         $this->assertEquals($client->getContainer()->get('router')->generate('facebook_login'), $client->getResponse()->headers->get('location'));

--- a/php/hireinsocial/tests/HireInSocial/Tests/Application/Functional/Symfony/OfferTest.php
+++ b/php/hireinsocial/tests/HireInSocial/Tests/Application/Functional/Symfony/OfferTest.php
@@ -16,7 +16,7 @@ final class OfferTest extends WebTestCase
         $client = static::createClient();
         $this->systemContext->createSpecialization($specialization);
 
-        $client->request('GET', $client->getContainer()->get('router')->generate('offer_success', ['specialization' => $specialization]));
+        $client->request('GET', $client->getContainer()->get('router')->generate('offer_success', ['specSlug' => $specialization]));
         $this->assertEquals(200, $client->getResponse()->getStatusCode());
     }
 
@@ -29,7 +29,7 @@ final class OfferTest extends WebTestCase
 
         $offer = $this->system()->query(OfferQuery::class)->findAll(OfferFilter::allFor($specialization))->first();
 
-        $client->request('GET', $client->getContainer()->get('router')->generate('offer', ['slug' => $offer->slug()]));
+        $client->request('GET', $client->getContainer()->get('router')->generate('offer', ['offerSlug' => $offer->slug()]));
         $this->assertEquals(200, $client->getResponse()->getStatusCode());
     }
 }

--- a/php/hireinsocial/tests/HireInSocial/Tests/Application/Functional/Symfony/SpecializationTest.php
+++ b/php/hireinsocial/tests/HireInSocial/Tests/Application/Functional/Symfony/SpecializationTest.php
@@ -17,7 +17,7 @@ final class SpecializationTest extends WebTestCase
         $this->systemContext->postToFacebookGroup('FB_USER_ID_1', $specialization);
         $this->systemContext->postToFacebookGroup('FB_USER_ID_2', $specialization);
 
-        $crawler = $client->request('GET', $client->getContainer()->get('router')->generate('specialization_offers', ['slug' => $specialization]));
+        $crawler = $client->request('GET', $client->getContainer()->get('router')->generate('specialization_offers', ['specSlug' => $specialization]));
 
         $this->assertEquals(200, $client->getResponse()->getStatusCode());
         $this->assertCount(2, $crawler->filter('.job-offer'));


### PR DESCRIPTION
Closes #12 

For better performance in search engines it's good to translate url paths into the current locale. 
If locale is pl_PL then most important urls should also be translated into polish, however there are some urls that can't or shouldn't be translated like for example:

* `/faq`
* `/facebook/login' 

Examples below:

All offers in PHP specialization:
![image](https://user-images.githubusercontent.com/1921950/52880280-d5332b80-3161-11e9-9767-9c1bc56c2233.png)

One specific offer in PHP specialization:
![image](https://user-images.githubusercontent.com/1921950/52880315-e9772880-3161-11e9-842b-8432e2bb7b36.png)

Add new offer for PHP specialization:
![image](https://user-images.githubusercontent.com/1921950/52880337-f72cae00-3161-11e9-815a-0e5a0fe625f6.png)
