### PR TITLE
Redirect user to new offer page after facebook login

### DIFF
--- a/php/hireinsocial/src/HireInSocial/UserInterface/Symfony/Controller/FacebookController.php
+++ b/php/hireinsocial/src/HireInSocial/UserInterface/Symfony/Controller/FacebookController.php
@@ -14,6 +14,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 final class FacebookController extends AbstractController
 {
     use FacebookAccess;
+    use RedirectAfterLogin;
 
     public const FACEBOOK_USER_TOKEN_SESSION_KEY = 'his_user_fb_user_auth_token';
 
@@ -60,6 +61,10 @@ final class FacebookController extends AbstractController
         $this->getUserId($this->facebook, $accessToken, $this->logger);
 
         $request->getSession()->set(self::FACEBOOK_USER_TOKEN_SESSION_KEY, (string) $accessToken);
+
+        if ($this->hasRedirection($request->getSession())) {
+            return $this->generateRedirection($request->getSession(), $this->get('router'));
+        }
 
         return $this->redirectToRoute('home');
     }

--- a/php/hireinsocial/src/HireInSocial/UserInterface/Symfony/Controller/OfferController.php
+++ b/php/hireinsocial/src/HireInSocial/UserInterface/Symfony/Controller/OfferController.php
@@ -30,6 +30,7 @@ use Symfony\Component\HttpFoundation\Response;
 final class OfferController extends AbstractController
 {
     use FacebookAccess;
+    use RedirectAfterLogin;
 
     private $facebook;
     /**
@@ -53,6 +54,8 @@ final class OfferController extends AbstractController
             );
         } catch (\Throwable $exception) {
             $this->logger->debug('Not authenticated, redirecting to facebook login.', ['exception' => $exception->getMessage()]);
+
+            $this->redirectAfterLogin($request->getSession(), 'offer_new', ['specialization' => $specialization]);
 
             return $this->redirectToRoute('facebook_login');
         }

--- a/php/hireinsocial/src/HireInSocial/UserInterface/Symfony/Controller/OfferController.php
+++ b/php/hireinsocial/src/HireInSocial/UserInterface/Symfony/Controller/OfferController.php
@@ -55,7 +55,7 @@ final class OfferController extends AbstractController
         } catch (\Throwable $exception) {
             $this->logger->debug('Not authenticated, redirecting to facebook login.', ['exception' => $exception->getMessage()]);
 
-            $this->redirectAfterLogin($request->getSession(), 'offer_new', ['specialization' => $specialization]);
+            $this->redirectAfterLogin($request->getSession(), 'offer_new', ['specSlug' => $specSlug]);
 
             return $this->redirectToRoute('facebook_login');
         }
@@ -89,7 +89,7 @@ final class OfferController extends AbstractController
                     )
                 ));
 
-                return $this->redirectToRoute('offer_success', ['specialization' => $specSlug]);
+                return $this->redirectToRoute('offer_success', ['specSlug' => $specSlug]);
             } catch (Exception $exception) {
                 // TODO: Show some user friendly error message in UI.
                 throw $exception;

--- a/php/hireinsocial/src/HireInSocial/UserInterface/Symfony/Controller/RedirectAfterLogin.php
+++ b/php/hireinsocial/src/HireInSocial/UserInterface/Symfony/Controller/RedirectAfterLogin.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HireInSocial\UserInterface\Symfony\Controller;
+
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\RouterInterface;
+
+trait RedirectAfterLogin
+{
+    public function redirectAfterLogin(SessionInterface $session, string $routeName, array $parameters = []) : void
+    {
+        $session->set('_redirect_to', ['route' => $routeName, 'parameters' => $parameters]);
+    }
+
+    public function hasRedirection(SessionInterface $session) : bool
+    {
+        return $session->has('_redirect_to');
+    }
+
+    public function generateRedirection(SessionInterface $session, RouterInterface $router) : RedirectResponse
+    {
+        if (!$this->hasRedirection($session)) {
+            throw new NotFoundHttpException('Redirection not found');
+        }
+
+        $redirection = $session->get('_redirect_to');
+
+        $session->remove('_redirect_to');
+
+        return new RedirectResponse($router->generate($redirection['route'], $redirection['parameters']));
+    }
+}


### PR DESCRIPTION
Closes #11 
Before user can post new job offer he needs to authenticate himself through Facebook (other methods coming soon). Facebook authentication redirects him to facebook page, then is redirected back to Hire in Social (`facebook_login_success`). 
So far user was redirected back to home page but it's clearly bad user experience because he needs to click "Post new offer" once again. 
This PR changes this behavior, now after getting back from Facebook user will be redirected to `offer_new` route. 

**Heads up**
You might notice that there are no tests in this PR, thats obviously not good but let me explain. 
In order to test this feature properly I would need to emulate redirecting to facebook and back, preparing this code would take me much longer than I spent building whole feature (it took me around 15 minutes). I don't think it's worth it, not at this point. 
I'm also planning to actually create user entry in the database in order to allow authentication through different platforms (Github, Gmail etc). I'm afraid that adding sophisticated test case would only slow me down in the future. 